### PR TITLE
Update bos_token bug

### DIFF
--- a/swift/llm/template/base.py
+++ b/swift/llm/template/base.py
@@ -20,6 +20,7 @@ from torch.nn.utils.rnn import pad_sequence
 from transformers import StoppingCriteriaList
 from transformers.integrations import is_deepspeed_zero3_enabled
 from transformers.utils import strtobool
+from transformers import PreTrainedTokenizerBase
 
 from swift.utils import get_dist_setting, get_env_args, get_logger, use_torchacc
 from ..utils import Processor, ProcessorMixin
@@ -670,7 +671,9 @@ class Template(ProcessorMixin):
             system: Optional[str] = None,
             query: Optional[str] = None,
             response: Optional[str] = None,
-            round0: Optional[int] = None) -> None:
+            round0: Optional[int] = None,
+            tokenizer: Optional[PreTrainedTokenizerBase] = None
+    ) -> None:
         """Concat context list and replace placeholder"""
         round1 = None
         if round0 is not None:
@@ -689,10 +692,14 @@ class Template(ProcessorMixin):
                     if new_str is not None and old_str in context:
                         assert isinstance(new_str, str), f'new_str: {new_str}'
                         context = context.replace(old_str, new_str)
+                res_context_list.append(context)
+                res_context_type.append(ContextType.OTHER)
             if len(context) == 0:
                 continue
-            res_context_list.append(context)
-            res_context_type.append(ContextType.OTHER)
+            if isinstance(context, list) and isinstance(context[0], int):
+                context = tokenizer.decode(context)
+                res_context_list.append(context)
+                res_context_type.append(ContextType.OTHER)
 
     def _simplify_context_list(self, context_list: List[Context], loss_scale_list: List[float],
                                inputs: StdTemplateInputs) -> Tuple[List[Context], List[float]]:
@@ -1040,15 +1047,16 @@ class Template(ProcessorMixin):
             bos_token = all_tokens[:idx]
             sep_token = all_tokens[idx + 1:]
             if bos_token:
-                res_context_list.append(bos_token)
+                res_context_list.append(self.tokenizer.bos_token)
+                # res_context_list.append(bos_token)
                 res_context_types.append(ContextType.OTHER)
 
         if self.template_meta.is_post_system or not system:
             prefix = template_meta.prefix
         else:
             prefix = template_meta.system_prefix
-        self._concat_context_list(prefix, res_context_list, res_context_types, system=system)
-
+        self._concat_context_list(prefix, res_context_list, res_context_types, system=system, tokenizer=self.tokenizer)        
+        
         n_round = len(inputs.messages) // 2
         for i, (query_message, response_message) in enumerate(zip(inputs.messages[::2], inputs.messages[1::2])):
             query_role, query = query_message['role'], query_message['content']


### PR DESCRIPTION
# PR type
- [issue](https://github.com/modelscope/ms-swift/issues/4808) Bug Fix 

# PR information
使用deepseek-ai/deepseek-coder-6.7b-base模型做grpo
问题表现同https://github.com/modelscope/ms-swift/issues/4785，但错误不一样
当前错误代码错误在swift/llm/template/base.py的_swift_encode函数，涉及的代码行如下：
`

    if self.template_meta.is_post_system or not system:

        prefix = template_meta.prefix

    else:
        prefix = template_meta.system_prefix
    self._concat_context_list(prefix, res_context_list, res_context_types, system=system)
`
debug发现prefix是 [[32013]], 对应的token是‘<｜begin▁of▁sentence｜>’，导致这个问题的原因在swift/llm/template/template_meta.py的init()函数的执行，将prefix这类值转成tokenid后替换该属性的值。
为了适配完整而正确的prompt，需要将token_id=32013,decode回‘<｜begin▁of▁sentence｜>’，这样行程的prompt为：‘<｜begin▁of▁sentence｜>User:xx\nAssitant:xx’

代码是最新的main分支的代码：swift.version: 3.6.0.dev0

解决方法：
将prefix=[[32013]]，返回成token拼接到prompt中，注意这是一个简单的方法。
要彻底采用通用方案解决的话应该在swift/llm/template/template_meta.py文件中保存prefix的token值，如有必要也保存prefix的token_id值，其他如suffix类似，为了防止直接修改带来不可预知的问题，这里采用最小修改的办法先解决该问题。
